### PR TITLE
Fix #53, Fix #56: Don't corrupt notebook.json when no oauth_client_id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ python:
   - 3.6
   - pypy
 sudo: false
-cache:
-  directories:
-  - "~/.cache/pip"
+cache: pip
 install:
   - pip install tox codecov
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - 3.5
   - 3.6
   - pypy
-  - pypy3
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: python
-python: 3.5
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy
+  - pypy3
 sudo: false
 cache:
   directories:
   - "~/.cache/pip"
-env:
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=py35
-  - TOXENV=pypy
 install:
   - pip install tox codecov
 script:
-  - tox -v
+  - tox -v -e py
 after_success:
   - codecov

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         'notebook >= 4.2',
         'jupyter',
         'requests',
+        'six',
         'widgetsnbextension',
     ],
     url='https://github.com/mozilla/jupyter-notebook-gist',

--- a/src/jupyter_notebook_gist/config.py
+++ b/src/jupyter_notebook_gist/config.py
@@ -19,6 +19,9 @@ class NotebookGist(LoggingConfigurable):
         super(NotebookGist, self).__init__(*args, **kwargs)
         # update the frontend settings with the currently passed
         # OAUTH client id
+        client_id = self.config.NotebookGist.oauth_client_id
+        if not isinstance(client_id, (str, bytes)):
+            client_id = None
         self.config_manager.update('notebook', {
-            'oauth_client_id': self.config.NotebookGist.oauth_client_id,
+            'oauth_client_id': client_id,
         })

--- a/src/jupyter_notebook_gist/config.py
+++ b/src/jupyter_notebook_gist/config.py
@@ -1,3 +1,4 @@
+import six
 from traitlets.config import LoggingConfigurable
 from traitlets.traitlets import Unicode
 
@@ -20,7 +21,7 @@ class NotebookGist(LoggingConfigurable):
         # update the frontend settings with the currently passed
         # OAUTH client id
         client_id = self.config.NotebookGist.oauth_client_id
-        if not isinstance(client_id, (str, bytes)):
+        if not isinstance(client_id, six.string_types):
             client_id = None
         self.config_manager.update('notebook', {
             'oauth_client_id': client_id,

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ deps:
     flake8>=3.5
     pytest-flake8>=0.5
     pytest>=2.8.0
-    tornado>=4.3.0
 
 [flake8]
 ignore = E501

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 recreate = true
 usedevelop = true
-envlist = py27, py33, py34, py35, pypy
+envlist = py27, py34, py35, py36, pypy
 
 [testenv]
 commands =
@@ -17,9 +17,10 @@ deps:
     pytest-coverage
     pytest-isort
     pytest-cache>=1.0
-    flake8<3.0.0
+    flake8>=3.5
     pytest-flake8>=0.5
     pytest>=2.8.0
+    tornado>=4.3.0
 
 [flake8]
 ignore = E501


### PR DESCRIPTION
When there is no `c.NotebookGist.oauth_client_id` in jupyter_notebook_config.py,
`self.config.NotebookGist.oauth_client_id` is a lazy value, which can't be
serialized to JSON.  This crashes the writing of `notebook.json` by Jupyter,
and corrupts the `notebook.json` file.  This fix makes sure that value is a
string, otherwise it just sets it to `None`.  When `None`, the frontend will
helpfully warn (as it always has) that the user hasn't set up their oauth ids.

r? @jezdez 