### PR TITLE
Attempt to fix Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ python:
   - 3.6
   - pypy
 sudo: false
-cache:
-  directories:
-  - "~/.cache/pip"
+cache: pip
 install:
   - pip install tox codecov
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - 3.5
   - 3.6
   - pypy
-  - pypy3
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: python
-python: 3.5
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy
+  - pypy3
 sudo: false
 cache:
   directories:
   - "~/.cache/pip"
-env:
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=py35
-  - TOXENV=pypy
 install:
   - pip install tox codecov
 script:
-  - tox -v
+  - tox -v -e py
 after_success:
   - codecov

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ deps:
     flake8>=3.5
     pytest-flake8>=0.5
     pytest>=2.8.0
-    tornado>=4.3.0
 
 [flake8]
 ignore = E501

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 recreate = true
 usedevelop = true
-envlist = py27, py33, py34, py35, pypy
+envlist = py27, py34, py35, py36, pypy
 
 [testenv]
 commands =
@@ -17,9 +17,10 @@ deps:
     pytest-coverage
     pytest-isort
     pytest-cache>=1.0
-    flake8<3.0.0
+    flake8>=3.5
     pytest-flake8>=0.5
     pytest>=2.8.0
+    tornado>=4.3.0
 
 [flake8]
 ignore = E501


### PR DESCRIPTION
Adds Python 3.6, drops Python 3.3

Fixes version conflict around flake8

Adds tornado (which wasn't getting installed automatically into pypy)

This also uses a different Travis CI VM configuration for each Python version, rather than using the same one and having tox pick different versions.  It seems recent Travis VMs (such as python-3.6) don't have multiple Python versions installed anymore.