### PR TITLE
Fix #60: Fix download notebook to server.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license='MPL2',
     install_requires=[
         'ipython >= 4',
-        'notebook >= 4.2',
+        'notebook >= 4.3.1',
         'jupyter',
         'requests',
         'six',

--- a/src/jupyter_notebook_gist/static/extension.js
+++ b/src/jupyter_notebook_gist/static/extension.js
@@ -109,20 +109,24 @@ define([
     }
 
     var download_nb_on_server = function(url, name, force_download) {
-        var xhr = new XMLHttpRequest();
         var nb_info = {
             nb_url: url,
             nb_name: window.btoa(name),
             force_download: force_download
         }
-        xhr.open("POST",  "/download_notebook", true);
-        xhr.setRequestHeader('Content-Type', 'application/json');
-        xhr.onload = function () {
+        utils.ajax({
+            url: "/download_notebook",
+            type: "POST",
+            dataType: "json",
+            data: JSON.stringify(nb_info)
+        }).fail(function(xhr, textStatus) {
             if (xhr.status == 409) {
                 // 409 Conflict
                 // used if file already exists
-                var newname = prompt("File already exists. Please enter a new name.\nNote: This may overwrite existing files.",
-                                     name);
+                var newname = prompt(
+                    "File already exists. Please enter a new name.\n" +
+                    "Note: This may overwrite existing files.",
+                    name);
                 if (newname == "" || newname == null) {
                     // prompt() returns "" if empty value, or null
                     // if user clicked cancel, want to abort in either case
@@ -130,12 +134,12 @@ define([
                 }
                 download_nb_on_server(url, newname, true);
             } else if (xhr.status == 200) {
-                window.open(url_path_split(Jupyter.notebook.notebook_path)[0] + encodeURIComponent(this.responseText));
+                window.open(url_path_split(Jupyter.notebook.notebook_path)[0] + \
+                            encodeURIComponent(this.responseText));
             } else if (xhr.status == 400) {
                 alert("File did not download");
             }
-        };
-        xhr.send(JSON.stringify(nb_info));
+        });
     }
 
     var load_public_user_gists = function() {


### PR DESCRIPTION
Since 4.3.0, Jupyter requires that a xsrf token is passed with all requests
to the server.

This uses Jupyter's utils.ajax API call to make the request which is a thin
wrapper around jquery.ajax that handles the xsrf authentication.

Downside is that this change requires a minimum version of Jupyter notebook
of 4.3.1