### PR TITLE
Fix #46: Add loading controls to tree page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ jupyter notebook --NotebookGist.oauth_client_id="<my_client_id>" --NotebookGist.
 
 ## Changelog
 
+### Master
+
+- Buttons for loading gists are now available on the "tree" (file manager) page
+  in Jupyter.
+
+- **IMPORTANT** Requires manual step to enable after running pip install
+  (see installation docs)!
+
+  To update:
+
+  1. Fully uninstall the extension first:
+
+    ```
+    jupyter serverextension disable --py jupyter_notebook_gist
+    jupyter nbextension disable --py jupyter_notebook_gist
+    jupyter nbextension uninstall --py jupyter_notebook_gist
+    pip uninstall jupyter-notebook-gist
+    ```
+
+  2. Follow the instructions above to reinstall
+
 ### 0.4.0 (2016-07-06)
 
 - Refactored config system to be able to configure it via CLI options or

--- a/src/jupyter_notebook_gist/__init__.py
+++ b/src/jupyter_notebook_gist/__init__.py
@@ -5,27 +5,28 @@ from .handlers import GistHandler, DownloadNotebookHandler, LoadGistHandler
 
 
 def _jupyter_nbextension_paths():
-    return [{
-        'section': 'notebook',
-        # the path is relative to the `jupyter_notebook_gist` directory
-        'src': 'static',
-        # directory in the `nbextension/` namespace
-        'dest': 'jupyter-notebook-gist',
-        # _also_ in the `nbextension/` namespace
-        'require': 'jupyter-notebook-gist/notebook-extension'
-    },
-    {
-        'section': 'tree',
-        'src': 'static',
-        'dest': 'jupyter-notebook-gist',
-        'require': 'jupyter-notebook-gist/tree-extension'
-    },
-    {
-        'section': 'common',
-        'src': 'static',
-        'dest': 'jupyter-notebook-gist',
-        'require': 'jupyter-notebook-gist/common'
-    },
+    return [
+        {
+            'section': 'notebook',
+            # the path is relative to the `jupyter_notebook_gist` directory
+            'src': 'static',
+            # directory in the `nbextension/` namespace
+            'dest': 'jupyter-notebook-gist',
+            # _also_ in the `nbextension/` namespace
+            'require': 'jupyter-notebook-gist/notebook-extension'
+        },
+        {
+            'section': 'tree',
+            'src': 'static',
+            'dest': 'jupyter-notebook-gist',
+            'require': 'jupyter-notebook-gist/tree-extension'
+        },
+        {
+            'section': 'common',
+            'src': 'static',
+            'dest': 'jupyter-notebook-gist',
+            'require': 'jupyter-notebook-gist/common'
+        },
     ]
 
 

--- a/src/jupyter_notebook_gist/__init__.py
+++ b/src/jupyter_notebook_gist/__init__.py
@@ -12,8 +12,21 @@ def _jupyter_nbextension_paths():
         # directory in the `nbextension/` namespace
         'dest': 'jupyter-notebook-gist',
         # _also_ in the `nbextension/` namespace
-        'require': 'jupyter-notebook-gist/extension',
-    }]
+        'require': 'jupyter-notebook-gist/notebook-extension'
+    },
+    {
+        'section': 'tree',
+        'src': 'static',
+        'dest': 'jupyter-notebook-gist',
+        'require': 'jupyter-notebook-gist/tree-extension'
+    },
+    {
+        'section': 'common',
+        'src': 'static',
+        'dest': 'jupyter-notebook-gist',
+        'require': 'jupyter-notebook-gist/common'
+    },
+    ]
 
 
 def _jupyter_server_extension_paths():

--- a/src/jupyter_notebook_gist/static/common.js
+++ b/src/jupyter_notebook_gist/static/common.js
@@ -1,58 +1,48 @@
-/*
-Run to enable this:
-
-jupyter serverextension enable --py jupyter_notebook_gist
-jupyter nbextension install --py jupyter_notebook_gist
-jupyter nbextension enable --py jupyter_notebook_gist
-*/
-function get_base_path() {
-    var loc = window.location;
-    var proto = loc.protocol;
-    var host = loc.hostname;
-    var port = loc.port;
-
-    var base = proto + "//" + host;
-    if (parseInt(port) != 80) {
-        base += ":" + port;
-    }
-    return base;
-}
-
-function url_path_split(path) {
-    var idx = path.lastIndexOf('/');
-    if (idx === -1) {
-        return ['', path];
-    } else {
-        return [ path.slice(0, idx), path.slice(idx + 1) ];
-    }
-}
-
-function is_url_valid(url) {
-    return /^(https?|s?ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i.test(url);
-}
-
 define([
     'base/js/namespace',
     'base/js/utils',
-    'moment'
-], function (Jupyter, utils, moment) {
+    'moment',
+    'services/config'
+], function(Jupyter, utils, moment, config) {
+    function get_base_path() {
+        var loc = window.location;
+        var proto = loc.protocol;
+        var host = loc.hostname;
+        var port = loc.port;
+
+        var base = proto + "//" + host;
+        if (parseInt(port) != 80) {
+            base += ":" + port;
+        }
+        return base;
+    }
+
+    function url_path_split(path) {
+        var idx = path.lastIndexOf('/');
+        if (idx === -1) {
+            return ['.', path];
+        } else {
+            return [ path.slice(0, idx), path.slice(idx + 1) ];
+        }
+    }
+
+    function is_url_valid(url) {
+        return /^(https?|s?ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i.test(url);
+    }
+
     var github_redirect_uri = get_base_path() + "/create_gist";
-    var gist_notebook = function () {
-        // Save the notebook and create a checkpoint to ensure that we create
-        // the gist using the most up-to-date content
-        Jupyter.notebook.save_checkpoint();
 
-        var github_client_id = Jupyter.notebook.config.data.oauth_client_id;
-        // Get notebook path and encode it in base64
-        // Characters like # get decoded by the github API and will mess up
-        // getting the file path on the server if we use URI percent encoding,
-        // so we use base64 instead
-        var nb_path = window.btoa(Jupyter.notebook.base_url + Jupyter.notebook.notebook_path);
-
-        // Start OAuth dialog
-        window.open("https://github.com/login/oauth/authorize?client_id=" + github_client_id +
-          "&scope=gist&redirect_uri=" + github_redirect_uri + "?nb_path=" + nb_path);
-    };
+    // Get the server side path to download to.
+    var get_download_path = function() {
+        if (Jupyter.hasOwnProperty('notebook')) {
+            // On a notebook page
+            return url_path_split(Jupyter.notebook.notebook_path)[0];
+        } else if (Jupyter.hasOwnProperty('notebook_list')) {
+            return Jupyter.notebook_list.notebook_path;
+        } else {
+            return '';
+        }
+    }
 
     var load_from_url = function() {
         var url = prompt("Enter the URL to a Gist or a .ipynb.");
@@ -111,7 +101,7 @@ define([
     var download_nb_on_server = function(url, name, force_download) {
         var nb_info = {
             nb_url: url,
-            nb_name: window.btoa(name),
+            nb_name: window.btoa(get_download_path() + '/' + name),
             force_download: force_download
         }
         utils.ajax({
@@ -134,8 +124,8 @@ define([
                 }
                 download_nb_on_server(url, newname, true);
             } else if (xhr.status == 200) {
-                window.open(url_path_split(Jupyter.notebook.notebook_path)[0] + \
-                            encodeURIComponent(this.responseText));
+                window.open(
+                    '/notebooks/' + encodeURIComponent(xhr.responseText));
             } else if (xhr.status == 400) {
                 alert("File did not download");
             }
@@ -177,6 +167,7 @@ define([
     var auth_window;
     window.addEventListener('message', function(event) {
         if (event.origin != get_base_path()) return;
+        if (auth_window === undefined) return;
         auth_window.close();
         Jupyter.dialog.modal({
             title: "All User Gists",
@@ -188,15 +179,13 @@ define([
     });
 
     var load_all_user_gists = function () {
-        var redirect_uri = get_base_path() + "/load_user_gists"
-
-        var github_client_id = Jupyter.notebook.config.data.oauth_client_id;
-        var nb_path = window.btoa(Jupyter.notebook.base_url + Jupyter.notebook.notebook_path);
-
-        auth_window = window.open("https://github.com/login/oauth/authorize?client_id=" + github_client_id +
-                                  "&scope=gist&redirect_uri=" + redirect_uri, "", "width=550, height=500");
+        var redirect_uri = get_base_path() + "/load_user_gists";
+        get_client_id(function(client_id) {
+            auth_window = window.open(
+                "https://github.com/login/oauth/authorize?client_id=" + client_id +
+                    "&scope=gist&redirect_uri=" + redirect_uri, "", "width=550, height=500");
+        });
     };
-
 
     var format_user_gists = function(responseText) {
         var body = $('<table/>').attr({class: "table", id: "my_table"});
@@ -273,6 +262,18 @@ define([
         });
     }
 
+    var get_client_id = function(callback) {
+        var common_options = {
+            base_url: utils.get_body_data("baseUrl"),
+            notebook_path: utils.get_body_data("notebookPath"),
+        };
+        var cfg = new config.ConfigSection('notebook', common_options);
+        cfg.loaded.then(function() {
+            callback(cfg.data.oauth_client_id);
+        });
+        cfg.load();
+    }
+
     var is_valid_client_id = function(client_id) {
         if (client_id === "my_client_id" || client_id === null || client_id === undefined) {
             return false;
@@ -280,55 +281,13 @@ define([
         return true;
     }
 
-    var gist_button = function () {
-        if (!Jupyter.toolbar) {
-            $([Jupyter.events]).on("app_initialized.NotebookApp", gist_button);
-            return;
-        }
-
-        if (!is_valid_client_id(Jupyter.notebook.config.data.oauth_client_id)) {
-            Jupyter.toolbar.add_buttons_group([{
-                'label':    'jupyter-notebook-gist setup',
-                'icon':     'fa-github',
-                'callback': setup_info,
-                'id':       'setup_info'
-            }]);
-
-            return;
-        }
-
-        if ($("#gist_notebook").length === 0) {
-            Jupyter.toolbar.add_buttons_group([
-                {
-                    'label'   : 'save notebook as gist',
-                    'icon'    : 'fa-github',
-                    'callback': gist_notebook,
-                    'id'      : 'gist_notebook'
-                }, {
-                    'label'   : 'load notebook from URL',
-                    'icon'    : 'fa-link',
-                    'callback': load_from_url,
-                    'id'      : 'load_notebook_from_url'
-                }, {
-                    'label'   : 'load public user gists',
-                    'icon'    : 'fa-list-alt',
-                    'callback': load_public_user_gists,
-                    'id'      : 'load_public_user_gists',
-                }, {
-                    'label'   : 'load all user gists',
-                    'icon'    : 'fa-list',
-                    'callback': load_all_user_gists,
-                    'id'      : 'load_all_user_gists',
-                }
-            ]);
-        }
-    };
-
-    var load_ipython_extension = function () {
-        gist_button();
-    };
-
     return {
-        load_ipython_extension: load_ipython_extension
+        github_redirect_uri: github_redirect_uri,
+        load_from_url: load_from_url,
+        load_public_user_gists: load_public_user_gists,
+        load_all_user_gists: load_all_user_gists,
+        get_client_id: get_client_id,
+        is_valid_client_id: is_valid_client_id,
+        setup_info: setup_info
     };
 });

--- a/src/jupyter_notebook_gist/static/common.js
+++ b/src/jupyter_notebook_gist/static/common.js
@@ -17,26 +17,20 @@ define([
         return base;
     }
 
-    function url_path_split(path) {
-        var idx = path.lastIndexOf('/');
-        if (idx === -1) {
-            return ['.', path];
-        } else {
-            return [ path.slice(0, idx), path.slice(idx + 1) ];
-        }
-    }
-
     function is_url_valid(url) {
         return /^(https?|s?ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i.test(url);
     }
 
-    var github_redirect_uri = get_base_path() + "/create_gist";
+    var github_redirect_uri = (
+        get_base_path() +
+        utils.get_body_data("baseUrl") +
+        "create_gist");
 
     // Get the server side path to download to.
     var get_download_path = function() {
         if (Jupyter.hasOwnProperty('notebook')) {
             // On a notebook page
-            return url_path_split(Jupyter.notebook.notebook_path)[0];
+            return utils.url_path_split(Jupyter.notebook.notebook_path)[0];
         } else if (Jupyter.hasOwnProperty('notebook_list')) {
             return Jupyter.notebook_list.notebook_path;
         } else {
@@ -101,7 +95,8 @@ define([
     var download_nb_on_server = function(url, name, force_download) {
         var nb_info = {
             nb_url: url,
-            nb_name: window.btoa(get_download_path() + '/' + name),
+            nb_name: window.btoa(
+                utils.url_path_join(get_download_path(), name)),
             force_download: force_download
         }
         utils.ajax({
@@ -125,7 +120,10 @@ define([
                 download_nb_on_server(url, newname, true);
             } else if (xhr.status == 200) {
                 window.open(
-                    '/notebooks/' + encodeURIComponent(xhr.responseText));
+                    utils.url_path_join(
+                        utils.get_body_data("baseUrl"),
+                        'notebooks',
+                        encodeURIComponent(xhr.responseText)));
             } else if (xhr.status == 400) {
                 alert("File did not download");
             }
@@ -179,7 +177,10 @@ define([
     });
 
     var load_all_user_gists = function () {
-        var redirect_uri = get_base_path() + "/load_user_gists";
+        var redirect_uri = (
+            get_base_path() +
+                utils.get_body_data("baseUrl") +
+                "load_user_gists");
         get_client_id(function(client_id) {
             auth_window = window.open(
                 "https://github.com/login/oauth/authorize?client_id=" + client_id +

--- a/src/jupyter_notebook_gist/static/notebook-extension.js
+++ b/src/jupyter_notebook_gist/static/notebook-extension.js
@@ -1,0 +1,77 @@
+
+define([
+    'base/js/namespace',
+    'nbextensions/jupyter-notebook-gist/common'
+], function (Jupyter, common) {
+    var gist_notebook = function() {
+        // Save the notebook and create a checkpoint to ensure that we create
+        // the gist using the most up-to-date content
+        Jupyter.notebook.save_checkpoint();
+
+        var github_client_id = Jupyter.notebook.config.data.oauth_client_id;
+        // Get notebook path and encode it in base64
+        // Characters like # get decoded by the github API and will mess up
+        // getting the file path on the server if we use URI percent encoding,
+        // so we use base64 instead
+        var nb_path = window.btoa(Jupyter.notebook.base_url + Jupyter.notebook.notebook_path);
+
+        // Start OAuth dialog
+        window.open("https://github.com/login/oauth/authorize?client_id=" + github_client_id +
+                    "&scope=gist&redirect_uri=" + common.github_redirect_uri +
+                    "?nb_path=" + nb_path);
+    }
+
+    var create_gist_buttons = function () {
+        if (!Jupyter.toolbar) {
+            $([Jupyter.events]).on("app_initialized.NotebookApp", create_gist_buttons);
+            return;
+        }
+
+        common.get_client_id(function(client_id) {
+            if (!common.is_valid_client_id(client_id)) {
+                Jupyter.toolbar.add_buttons_group([{
+                    'label':    'jupyter-notebook-gist setup',
+                    'icon':     'fa-github',
+                    'callback': common.setup_info,
+                    'id':       'setup_info'
+                }]);
+
+                return;
+            }
+
+            if ($("#gist_notebook").length === 0) {
+                Jupyter.toolbar.add_buttons_group([
+                    {
+                        'label'   : 'save notebook as gist',
+                        'icon'    : 'fa-github',
+                        'callback': gist_notebook,
+                        'id'      : 'gist_notebook'
+                    }, {
+                        'label'   : 'load notebook from URL',
+                        'icon'    : 'fa-link',
+                        'callback': common.load_from_url,
+                        'id'      : 'load_notebook_from_url'
+                    }, {
+                        'label'   : 'load public user gists',
+                        'icon'    : 'fa-list-alt',
+                        'callback': common.load_public_user_gists,
+                        'id'      : 'load_public_user_gists',
+                    }, {
+                        'label'   : 'load all user gists',
+                        'icon'    : 'fa-list',
+                        'callback': common.load_all_user_gists,
+                        'id'      : 'load_all_user_gists',
+                    }
+                ]);
+            }
+        });
+    };
+
+    var load_ipython_extension = function () {
+        create_gist_buttons();
+    };
+
+    return {
+        load_ipython_extension: load_ipython_extension
+    };
+});

--- a/src/jupyter_notebook_gist/static/tree-extension.js
+++ b/src/jupyter_notebook_gist/static/tree-extension.js
@@ -1,0 +1,67 @@
+define([
+    'nbextensions/jupyter-notebook-gist/common'
+], function (common) {
+    function add_toolbar_button(group, label, icon, callback, id) {
+        group.append(
+            $('<button/>')
+                .attr('class', 'btn btn-default')
+                .attr('title', label)
+                .attr('id', id)
+                .on('click', callback)
+                .append(
+                    $('<i/>')
+                        .attr('class', icon + ' fa'))
+                .append(
+                    $('<span/>')
+                        .attr('class', 'toolbar-btn-label')
+                        .text(label)
+                )
+        )
+    }
+
+    function add_gist_buttons() {
+        var group = $('<div/>')
+            .attr('class', 'btn-group')
+            .appendTo('#notebook_toolbar');
+
+        common.get_client_id(function(client_id) {
+            if (!common.is_valid_client_id(client_id)) {
+                add_toolbar_button(
+                    group,
+                    "jupyter-notebook-gist setup",
+                    "fa-github",
+                    common.setup_info,
+                    "setup_info");
+            } else {
+                add_toolbar_button(
+                    group,
+                    "load notebook from URL",
+                    "fa-link",
+                    common.load_from_url,
+                    "load_notebook_from_url");
+
+                add_toolbar_button(
+                    group,
+                    "load public user gists",
+                    "fa-list-alt",
+                    common.load_public_user_gists,
+                    "load_public_user_gists");
+
+                add_toolbar_button(
+                    group,
+                    "load all user gists",
+                    "fa-list",
+                    common.load_all_user_gists,
+                    "load_add_user_gists");
+            }
+        });
+    }
+
+    var load_ipython_extension = function () {
+        add_gist_buttons();
+    };
+
+    return {
+        load_ipython_extension: load_ipython_extension
+    };
+});


### PR DESCRIPTION
This adds the loading-related buttons to the tree page, but otherwise is 
the same code and functionality.

It reorganizes the code into a notebook extension, a tree extension (the
file browser page), and code that is common between the two.

Since extension files have been added, this requires uninstalling and
reinstalling the notebook extensions (as per our README.md).